### PR TITLE
Respect safe documents

### DIFF
--- a/lib/joint/instance_methods.rb
+++ b/lib/joint/instance_methods.rb
@@ -22,6 +22,7 @@ module Joint
           :_id          => send(name).id,
           :filename     => send(name).name,
           :content_type => send(name).type,
+          :safe         => safe?
         })
       end
       assigned_attachments.clear
@@ -46,5 +47,9 @@ module Joint
 
     def destroy_all_attachments
       self.class.attachment_names.map { |name| grid.delete(send(name).id) }
+    end
+
+    def safe?
+      _root_document.class.safe?
     end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -54,6 +54,10 @@ class Asset
   has_many :embedded_assets
 end
 
+class SafeAsset < Asset
+  safe
+end
+
 class EmbeddedAsset
   include MongoMapper::EmbeddedDocument
   plugin Joint

--- a/test/test_joint.rb
+++ b/test/test_joint.rb
@@ -461,7 +461,7 @@ describe "JointTest" do
     end
   end
 
-#   # What about when an embedded document is removed?
+  # What about when an embedded document is removed?
 
   describe "Assigning file name" do
     it "default to path" do
@@ -500,6 +500,15 @@ describe "JointTest" do
 
       model.file = @image
       assert model.valid?
+    end
+  end
+
+  describe "Assigning new attachments to a safe document" do
+    it "proxies the safe setting" do
+      doc = SafeAsset.new(:image => @image, :file => @file)
+      rewind_files
+      Mongo::Grid.any_instance.expects(:put).twice.with(anything, has_entries(safe: true))
+      doc.save
     end
   end
 


### PR DESCRIPTION
For documents like

```
class SafeAsset
  safe
  ...
end
```

Proxy the safe setting through to saving the attachments.
