### PR TITLE
Added configurable GridFS collection name.

### DIFF
--- a/lib/joint.rb
+++ b/lib/joint.rb
@@ -7,8 +7,9 @@ module Joint
   extend ActiveSupport::Concern
 
   included do
-    class_attribute :attachment_names
+    class_attribute :attachment_names, :joint_collection_name
     self.attachment_names = Set.new
+    self.joint_collection_name = 'fs'
     include attachment_accessor_module
   end
 

--- a/lib/joint/class_methods.rb
+++ b/lib/joint/class_methods.rb
@@ -1,5 +1,9 @@
 module Joint
   module ClassMethods
+    def set_joint_collection(name)
+      self.joint_collection_name = name
+    end
+
     def attachment_accessor_module
       @attachment_accessor_module ||= Module.new
     end

--- a/lib/joint/instance_methods.rb
+++ b/lib/joint/instance_methods.rb
@@ -1,6 +1,6 @@
 module Joint
   def grid
-    @grid ||= Mongo::Grid.new(database)
+    @grid ||= Mongo::Grid.new(database, joint_collection_name)
   end
 
   private

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -35,12 +35,12 @@ class Minitest::Test
     assert_difference(expression, 0, message, &block)
   end
 
-  def assert_grid_difference(difference=1, &block)
-    assert_difference("MongoMapper.database['fs.files'].find().count", difference, &block)
+  def assert_grid_difference(difference=1, collection_name='fs', &block)
+    assert_difference("MongoMapper.database['#{collection_name}.files'].find().count", difference, &block)
   end
 
-  def assert_no_grid_difference(&block)
-    assert_grid_difference(0, &block)
+  def assert_no_grid_difference(collection_name = 'fs', &block)
+    assert_grid_difference(0, collection_name, &block)
   end
 end
 
@@ -56,6 +56,14 @@ end
 
 class SafeAsset < Asset
   safe
+end
+
+class CustomCollectionAsset < Asset
+  set_joint_collection 'custom'
+end
+
+class CustomCollectionAssetSubclass < CustomCollectionAsset
+  attachment :video
 end
 
 class EmbeddedAsset
@@ -91,8 +99,9 @@ module JointTestHelpers
     f
   end
 
-  def grid
-    @grid ||= Mongo::Grid.new(MongoMapper.database)
+  def grid(collection_name = 'fs')
+    @grids ||= {}
+    @grids[collection_name] ||= Mongo::Grid.new(MongoMapper.database, collection_name)
   end
 
   def key_names

--- a/test/test_joint.rb
+++ b/test/test_joint.rb
@@ -564,4 +564,34 @@ describe "JointTest" do
       subject.file_id.must_be_instance_of(BSON::ObjectId)
     end
   end
+
+  describe "Joint collection configuration" do
+
+    it "has default gridfs collection" do
+      Asset.joint_collection_name.must_equal 'fs'
+    end
+
+    it "has custom gridfs collection" do
+      CustomCollectionAsset.joint_collection_name.must_equal 'custom'
+    end
+
+    it "inherits custom gridfs collection" do
+      CustomCollectionAssetSubclass.joint_collection_name.must_equal 'custom'
+    end
+
+    it "saves to the default gridfs collection" do
+      assert_grid_difference(2, 'fs') do
+        Asset.create(:image => @image, :file => @file)
+        rewind_files
+      end
+    end
+
+    it "saves to the custom gridfs collection" do
+      assert_grid_difference(2, 'custom') do
+        CustomCollectionAsset.create(:image => @image, :file => @file)
+        rewind_files
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
The GridFS collection used for the attachments can be configured via

```
class CustomAsset
  include MongoMapper::Document
  plugin Joint

  set_joint_collection 'custom'
end
```
